### PR TITLE
Something like this

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "sanity-plugin-hotspot-array",
   "version": "0.0.1",
   "description": "A configurable Custom Input for Arrays that will add and update items by clicking on an Image",
-  "main": "lib/HotspotArray.js",
+  "main": "lib/schemaType.js",
   "scripts": {
     "lint": "eslint .",
     "build": "sanipack build",

--- a/sanity.json
+++ b/sanity.json
@@ -3,5 +3,10 @@
     "source": "./src",
     "compiled": "./lib"
   },
-  "parts": []
+  "parts": [
+    {
+      "implements": "part:@sanity/base/schema-type",
+      "path": "schemaType"
+    }
+  ]
 }

--- a/src/schemaType.ts
+++ b/src/schemaType.ts
@@ -1,0 +1,7 @@
+import HotspotArray from "./HotspotArray"
+
+export default {
+  name: "hotspots",
+  type: "array",
+  inputComponent: HotspotArray
+}


### PR DESCRIPTION
Not tested, but gives the general idea. Defining a schema type part makes `hotspots` available in schemas in studios where the plugin is enabled