### PR TITLE
add option to search in parent for image field instead of document

### DIFF
--- a/src/HotspotArray.tsx
+++ b/src/HotspotArray.tsx
@@ -21,7 +21,7 @@ import Feedback from './Feedback'
 const imageStyle = {width: `100%`, height: `auto`}
 
 const HotspotArray = React.forwardRef((props, ref) => {
-  const {type, value, onChange, document: sanityDocument, parent} = props
+  const {type, value, onChange, document, parent} = props
   const {options} = type ?? {}
 
   // Attempt prevention of infinite loop in <FormBuilderInput />
@@ -33,8 +33,8 @@ const HotspotArray = React.forwardRef((props, ref) => {
   const displayImage = React.useMemo(() => {
     const builder = imageUrlBuilder(sanityClient).dataset(sanityClient.config().dataset)
     const urlFor = (source) => builder.image(source)
-    const hotspotImageParentObject = options?.hotspotImagePathInParent === true ? parent : sanityDocument
-    const hotspotImage = get(hotspotImageParentObject, options?.hotspotImagePath)
+    const imageHotspotPathRoot = props[options?.imageHotspotPathRoot] || document
+    const hotspotImage = get(imageHotspotPathRoot, options?.hotspotImagePath)
 
     if (hotspotImage?.asset?._ref) {
       const {aspectRatio} = getImageDimensions(hotspotImage.asset._ref)
@@ -46,7 +46,7 @@ const HotspotArray = React.forwardRef((props, ref) => {
     }
 
     return null
-  }, [parent, sanityDocument, type])
+  }, [type])
 
   const handleHotspotImageClick = React.useCallback((event) => {
     const {nativeEvent} = event

--- a/src/HotspotArray.tsx
+++ b/src/HotspotArray.tsx
@@ -21,19 +21,20 @@ import Feedback from './Feedback'
 const imageStyle = {width: `100%`, height: `auto`}
 
 const HotspotArray = React.forwardRef((props, ref) => {
-  const {type, value, onChange, document: sanityDocument} = props
+  const {type, value, onChange, document: sanityDocument, parent} = props
   const {options} = type ?? {}
 
   // Attempt prevention of infinite loop in <FormBuilderInput />
   // Re-renders can still occur if this Component is used again in a nested field
   const typeWithoutInputComponent = useUnsetInputComponent(type, type?.inputComponent)
 
-  // Finding the image from the document,
+  // Finding the image from the document or parent (if hotspotImagePathInParent is set to true),
   // using the path from the hotspot's `options` field
   const displayImage = React.useMemo(() => {
     const builder = imageUrlBuilder(sanityClient).dataset(sanityClient.config().dataset)
     const urlFor = (source) => builder.image(source)
-    const hotspotImage = get(sanityDocument, options?.hotspotImagePath)
+    const hotspotImageParentObject = options?.hotspotImagePathInParent === true ? parent : sanityDocument
+    const hotspotImage = get(hotspotImageParentObject, options?.hotspotImagePath)
 
     if (hotspotImage?.asset?._ref) {
       const {aspectRatio} = getImageDimensions(hotspotImage.asset._ref)
@@ -45,7 +46,7 @@ const HotspotArray = React.forwardRef((props, ref) => {
     }
 
     return null
-  }, [sanityDocument, type])
+  }, [parent, sanityDocument, type])
 
   const handleHotspotImageClick = React.useCallback((event) => {
     const {nativeEvent} = event

--- a/src/HotspotArray.tsx
+++ b/src/HotspotArray.tsx
@@ -20,6 +20,8 @@ import Feedback from './Feedback'
 
 const imageStyle = {width: `100%`, height: `auto`}
 
+const VALID_ROOT_PATHS = ['document', 'parent']
+
 const HotspotArray = React.forwardRef((props, ref) => {
   const {type, value, onChange, document, parent} = props
   const {options} = type ?? {}
@@ -33,7 +35,8 @@ const HotspotArray = React.forwardRef((props, ref) => {
   const displayImage = React.useMemo(() => {
     const builder = imageUrlBuilder(sanityClient).dataset(sanityClient.config().dataset)
     const urlFor = (source) => builder.image(source)
-    const imageHotspotPathRoot = props[options?.imageHotspotPathRoot] || document
+
+    const imageHotspotPathRoot = VALID_ROOT_PATHS.includes(options?.imageHotspotPathRoot) ? props[options.imageHotspotPathRoot] : document
     const hotspotImage = get(imageHotspotPathRoot, options?.hotspotImagePath)
 
     if (hotspotImage?.asset?._ref) {
@@ -46,7 +49,7 @@ const HotspotArray = React.forwardRef((props, ref) => {
     }
 
     return null
-  }, [type])
+  }, [type, document])
 
   const handleHotspotImageClick = React.useCallback((event) => {
     const {nativeEvent} = event
@@ -123,12 +126,16 @@ const HotspotArray = React.forwardRef((props, ref) => {
         </div>
       ) : (
         <Feedback>
-            {type?.options?.hotspotImagePath 
-              ? <>No Hotspot image found at path <code>{type?.options?.hotspotImagePath}</code></> 
+            {type?.options?.hotspotImagePath
+              ? <>No Hotspot image found at path <code>{type?.options?.hotspotImagePath}</code></>
               : <>Define a path in this field using to the image field in this document at <code>options.hotspotImagePath</code></>
             }
           </Feedback>
       )}
+        {type?.options?.imageHotspotPathRoot && !VALID_ROOT_PATHS.includes(type.options.imageHotspotPathRoot) &&
+        <Feedback>
+            The supplied imageHotspotPathRoot "{type.options.imageHotspotPathRoot}" is not valid, falling back to "document". Available values are "{VALID_ROOT_PATHS.join(', ')}".
+        </Feedback>}
       <FormBuilderInput {...props} type={typeWithoutInputComponent} ref={ref} />
     </Stack>
   )

--- a/src/HotspotArray.tsx
+++ b/src/HotspotArray.tsx
@@ -28,7 +28,7 @@ const HotspotArray = React.forwardRef((props, ref) => {
   // Re-renders can still occur if this Component is used again in a nested field
   const typeWithoutInputComponent = useUnsetInputComponent(type, type?.inputComponent)
 
-  // Finding the image from the document or parent (if hotspotImagePathInParent is set to true),
+  // Finding the image from the imageHotspotPathRoot (defaults to document),
   // using the path from the hotspot's `options` field
   const displayImage = React.useMemo(() => {
     const builder = imageUrlBuilder(sanityClient).dataset(sanityClient.config().dataset)


### PR DESCRIPTION
At the moment only images on document level can be used as a hotspot image source. With this PR images in parent objects can also be used as source.

When adding `hotspotImagePathInParent: true` in the field options, the parent is used to find the `hotspotImagePath` instead of the document. 