### PR TITLE
Bugfixes and style optimization

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   "author": "Simeon Griggs <simeon@sanity.io>",
   "license": "MIT",
   "dependencies": {
+    "@react-hookz/web": "^14.2.2",
     "@sanity/asset-utils": "^1.2.3",
     "@sanity/base": "^2.30.1",
     "@sanity/form-builder": "^2.30.1",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
   "author": "Simeon Griggs <simeon@sanity.io>",
   "license": "MIT",
   "dependencies": {
-    "@react-hookz/web": "^14.2.2",
     "@sanity/asset-utils": "^1.2.3",
     "@sanity/base": "^2.30.1",
     "@sanity/form-builder": "^2.30.1",

--- a/package.json
+++ b/package.json
@@ -29,26 +29,26 @@
   "license": "MIT",
   "dependencies": {
     "@sanity/asset-utils": "^1.2.3",
-    "@sanity/base": "^2.27.0",
-    "@sanity/form-builder": "^2.27.0",
-    "@sanity/ui": "^0.37.5",
-    "framer-motion": "^6.2.6",
-    "husky": "^7.0.4"
+    "@sanity/base": "^2.30.1",
+    "@sanity/form-builder": "^2.30.1",
+    "@sanity/ui": "^0.37.12",
+    "framer-motion": "^6.3.11",
+    "husky": "^8.0.1"
   },
   "devDependencies": {
-    "eslint": "^7.32.0",
-    "eslint-config-prettier": "^8.3.0",
-    "eslint-config-sanity": "^5.1.0",
-    "eslint-plugin-react": "^7.27.1",
-    "pinst": "^2.1.6",
-    "prettier": "^2.5.1",
+    "eslint": "^8.17.0",
+    "eslint-config-prettier": "^8.5.0",
+    "eslint-config-sanity": "^6.0.0",
+    "eslint-plugin-react": "^7.30.0",
+    "pinst": "^3.0.0",
+    "prettier": "^2.7.0",
     "sanipack": "^2.1.0"
   },
   "peerDependencies": {
-    "react": "^17.0.0",
-    "@sanity/util": "2.23.2",
     "@sanity/image-url": "1.0.1",
-    "lodash": "4.17.21"
+    "@sanity/util": "2.29.5",
+    "lodash": "4.17.21",
+    "react": "^17.0.2"
   },
   "bugs": {
     "url": "https://github.com/SimeonGriggs/sanity-plugin-hotspot-array/issues"

--- a/src/Feedback.tsx
+++ b/src/Feedback.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Card, Text } from '@sanity/ui'
+import {Card, Text} from '@sanity/ui'
 
 export default function Feedback({children}) {
   return (

--- a/src/Feedback.tsx
+++ b/src/Feedback.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import {Card, Text} from '@sanity/ui'
+import { Card, Text } from '@sanity/ui'
 
 export default function Feedback({children}) {
   return (

--- a/src/HotspotArray.tsx
+++ b/src/HotspotArray.tsx
@@ -75,7 +75,7 @@ const HotspotArray = React.forwardRef((props: any, ref) => {
     const y = Number(((nativeEvent.offsetY * 100) / nativeEvent.srcElement.height).toFixed(2))
     const description = `New Hotspot at ${x}% x ${y}%`
 
-    const newRow = {
+    const newRow: TSpot = {
       _key: randomKey(12),
       _type: `spot`,
       x,

--- a/src/HotspotArray.tsx
+++ b/src/HotspotArray.tsx
@@ -3,21 +3,21 @@
 // @ts-ignore
 import sanityClient from 'part:@sanity/base/client'
 // @ts-ignore
-import { withDocument } from 'part:@sanity/form-builder'
+import {withDocument} from 'part:@sanity/form-builder'
 
-import { getImageDimensions } from '@sanity/asset-utils'
-import { FormBuilderInput } from '@sanity/form-builder/lib/FormBuilderInput'
-import { insert, PatchEvent, set, setIfMissing } from '@sanity/form-builder/PatchEvent'
+import {getImageDimensions} from '@sanity/asset-utils'
+import {FormBuilderInput} from '@sanity/form-builder/lib/FormBuilderInput'
+import {insert, PatchEvent, set, setIfMissing} from '@sanity/form-builder/PatchEvent'
 import imageUrlBuilder from '@sanity/image-url'
-import { Card, Flex, Stack } from '@sanity/ui'
-import { randomKey } from '@sanity/util/content'
+import {Card, Flex, Stack} from '@sanity/ui'
+import {randomKey} from '@sanity/util/content'
 import get from 'lodash/get'
-import React, { useState } from 'react'
+import React, {useState} from 'react'
 
-import { IUseResizeObserverCallback, useDebouncedCallback, useResizeObserver } from '@react-hookz/web'
+import {IUseResizeObserverCallback, useDebouncedCallback, useResizeObserver} from '@react-hookz/web'
 import Feedback from './Feedback'
 import Spot from './Spot'
-import { useUnsetInputComponent } from './useUnsetInputComponent'
+import {useUnsetInputComponent} from './useUnsetInputComponent'
 
 const imageStyle = {width: `100%`, height: `auto`}
 

--- a/src/HotspotArray.tsx
+++ b/src/HotspotArray.tsx
@@ -91,11 +91,6 @@ const HotspotArray = React.forwardRef((props: any, ref) => {
 
   const handleHotspotMove: FnHotspotMove = React.useCallback(
     (key, x, y) => {
-      if (!Number(x) || !Number(y)) {
-        console.warn(`Missing or non-number X or Y`, {x, y})
-        return
-      }
-
       onChange(
         PatchEvent.from(
           // Set the `x` value of this array key item

--- a/src/HotspotArray.tsx
+++ b/src/HotspotArray.tsx
@@ -22,7 +22,16 @@ const imageStyle = {width: `100%`, height: `auto`}
 
 const VALID_ROOT_PATHS = ['document', 'parent']
 
-const HotspotArray = React.forwardRef((props, ref) => {
+export type FnHotspotMove = (key: string, x: number, y: number) => void
+
+export type TSpot = {
+	_key: string
+	_type: `spot`
+	x: number
+	y: number
+} & { [key: string]: unknown }
+
+const HotspotArray = React.forwardRef((props: any, ref) => {
   const {type, value, onChange, document, parent} = props
   const {options} = type ?? {}
 
@@ -73,7 +82,7 @@ const HotspotArray = React.forwardRef((props, ref) => {
     onChange(PatchEvent.from(setIfMissing([]), insert([newRow], 'after', [-1])))
   }, [])
 
-  const handleHotspotMove = React.useCallback(
+  const handleHotspotMove: FnHotspotMove = React.useCallback(
     (key, x, y) => {
       if (!Number(x) || !Number(y)) {
         console.warn(`Missing or non-number X or Y`, {x, y})
@@ -92,7 +101,7 @@ const HotspotArray = React.forwardRef((props, ref) => {
     [value]
   )
 
-  const hotspotImageRef = React.useRef(null)
+  const hotspotImageRef = React.useRef<HTMLImageElement | null>(null)
 
   return (
     <Stack space={[2,2,3]}>

--- a/src/HotspotArray.tsx
+++ b/src/HotspotArray.tsx
@@ -3,20 +3,20 @@
 // @ts-ignore
 import sanityClient from 'part:@sanity/base/client'
 // @ts-ignore
-import {withDocument} from 'part:@sanity/form-builder'
+import { withDocument } from 'part:@sanity/form-builder'
 
-import React from 'react'
-import {Card, Flex, Stack, Text} from '@sanity/ui'
-import {FormBuilderInput} from '@sanity/form-builder/lib/FormBuilderInput'
-import {randomKey} from '@sanity/util/content'
-import {PatchEvent, setIfMissing, set, insert} from '@sanity/form-builder/PatchEvent'
+import { getImageDimensions } from '@sanity/asset-utils'
+import { FormBuilderInput } from '@sanity/form-builder/lib/FormBuilderInput'
+import { insert, PatchEvent, set, setIfMissing } from '@sanity/form-builder/PatchEvent'
 import imageUrlBuilder from '@sanity/image-url'
-import {getImageDimensions} from '@sanity/asset-utils'
+import { Card, Flex, Stack } from '@sanity/ui'
+import { randomKey } from '@sanity/util/content'
 import get from 'lodash/get'
+import React from 'react'
 
+import Feedback from './Feedback'
 import Spot from './Spot'
 import { useUnsetInputComponent } from './useUnsetInputComponent'
-import Feedback from './Feedback'
 
 const imageStyle = {width: `100%`, height: `auto`}
 

--- a/src/HotspotArray.tsx
+++ b/src/HotspotArray.tsx
@@ -3,139 +3,142 @@
 // @ts-ignore
 import sanityClient from 'part:@sanity/base/client'
 // @ts-ignore
-import { withDocument } from 'part:@sanity/form-builder'
+import {withDocument} from 'part:@sanity/form-builder'
 
-import { IUseResizeObserverCallback, useDebouncedCallback, useResizeObserver } from '@react-hookz/web'
-import { getImageDimensions } from '@sanity/asset-utils'
-import { FormBuilderInput } from '@sanity/form-builder/lib/FormBuilderInput'
-import { insert, PatchEvent, set, setIfMissing } from '@sanity/form-builder/PatchEvent'
+import React from 'react'
+import {Card, Flex, Stack, Text} from '@sanity/ui'
+import {FormBuilderInput} from '@sanity/form-builder/lib/FormBuilderInput'
+import {randomKey} from '@sanity/util/content'
+import {PatchEvent, setIfMissing, set, insert} from '@sanity/form-builder/PatchEvent'
 import imageUrlBuilder from '@sanity/image-url'
-import { Card, Flex, Stack } from '@sanity/ui'
-import { randomKey } from '@sanity/util/content'
+import {getImageDimensions} from '@sanity/asset-utils'
 import get from 'lodash/get'
-import React, { useCallback, useRef, useState } from 'react'
 
-import Feedback from './Feedback'
 import Spot from './Spot'
 import { useUnsetInputComponent } from './useUnsetInputComponent'
+import Feedback from './Feedback'
 
-const imageStyle = { width: `100%`, height: `auto` }
+const imageStyle = {width: `100%`, height: `auto`}
 
 const VALID_ROOT_PATHS = ['document', 'parent']
 
-export type FnHotspotMove = (key: string, x: number, y: number) => void
-
-export type TSpot = {
-	_key: string
-	_type: `spot`
-	x: number
-	y: number
-} & { [key: string]: unknown }
-
-const HotspotArray = React.forwardRef((props: any, ref) => {
-	const { type, value, onChange, document } = props
-	const { options } = type ?? {}
+const HotspotArray = React.forwardRef((props, ref) => {
+  const {type, value, onChange, document, parent} = props
+  const {options} = type ?? {}
 
   // Attempt prevention of infinite loop in <FormBuilderInput />
-	// Re-renders can still occur if this Component is used again in a nested field
-	const typeWithoutInputComponent = useUnsetInputComponent(type, type?.inputComponent)
-	const imageHotspotPathRoot = React.useMemo(() => (VALID_ROOT_PATHS.includes(options?.imageHotspotPathRoot) ? props[options.imageHotspotPathRoot] : document), [])
+  // Re-renders can still occur if this Component is used again in a nested field
+  const typeWithoutInputComponent = useUnsetInputComponent(type, type?.inputComponent)
 
-	// Finding the image from the imageHotspotPathRoot (defaults to document),
-	// using the path from the hotspot's `options` field
-	const displayImage = React.useMemo(() => {
-		const builder = imageUrlBuilder(sanityClient).dataset(sanityClient.config().dataset)
-		const urlFor = (source) => builder.image(source)
+  // Finding the image from the imageHotspotPathRoot (defaults to document),
+  // using the path from the hotspot's `options` field
+  const displayImage = React.useMemo(() => {
+    const builder = imageUrlBuilder(sanityClient).dataset(sanityClient.config().dataset)
+    const urlFor = (source) => builder.image(source)
 
-		const hotspotImage = get(imageHotspotPathRoot, options?.hotspotImagePath)
+    const imageHotspotPathRoot = VALID_ROOT_PATHS.includes(options?.imageHotspotPathRoot) ? props[options.imageHotspotPathRoot] : document
+    const hotspotImage = get(imageHotspotPathRoot, options?.hotspotImagePath)
 
-		if (hotspotImage?.asset?._ref) {
-			const { aspectRatio } = getImageDimensions(hotspotImage.asset._ref)
-			const width = 600
-			const height = Math.round(width / aspectRatio)
-			const url = urlFor(hotspotImage).width(width).url()
+    if (hotspotImage?.asset?._ref) {
+      const {aspectRatio} = getImageDimensions(hotspotImage.asset._ref)
+      const width = 600
+      const height = Math.round(width / aspectRatio)
+      const url = urlFor(hotspotImage).width(width).url()
 
-			return { width, height, url }
-		}
+      return {width, height, url}
+    }
 
-		return null
-	}, [type, imageHotspotPathRoot])
+    return null
+  }, [type, document])
 
-	const handleHotspotImageClick = React.useCallback((event) => {
-		const { nativeEvent } = event
+  const handleHotspotImageClick = React.useCallback((event) => {
+    const {nativeEvent} = event
 
-		// Calculate the x/y percentage of the click position
-		const x = Number(((nativeEvent.offsetX * 100) / nativeEvent.srcElement.width).toFixed(2))
-		const y = Number(((nativeEvent.offsetY * 100) / nativeEvent.srcElement.height).toFixed(2))
-		const description = `New Hotspot at ${x}% x ${y}%`
+    // Calculate the x/y percentage of the click position
+    const x = Number(((nativeEvent.offsetX * 100) / nativeEvent.srcElement.width).toFixed(2))
+    const y = Number(((nativeEvent.offsetY * 100) / nativeEvent.srcElement.height).toFixed(2))
+    const description = `New Hotspot at ${x}% x ${y}%`
 
-		const newRow: TSpot = {
-			_key: randomKey(12),
-			_type: `spot`,
-			x,
-			y,
-		}
+    const newRow = {
+      _key: randomKey(12),
+      _type: `spot`,
+      x,
+      y,
+    }
 
-		if (options?.hotspotDescriptionPath) {
-			newRow[options.hotspotDescriptionPath] = description
-		}
+    if (options?.hotspotDescriptionPath) {
+      newRow[options.hotspotDescriptionPath] = description
+    }
 
-		onChange(PatchEvent.from(setIfMissing([]), insert([newRow], 'after', [-1])))
-	}, [])
+    onChange(PatchEvent.from(setIfMissing([]), insert([newRow], 'after', [-1])))
+  }, [])
 
-	const handleHotspotMove: FnHotspotMove = useCallback(
-		(key, x, y) => {
-			onChange(
-				PatchEvent.from(
-					// Set the `x` value of this array key item
-					set(x, [{ _key: key }, 'x']),
-					// Set the `y` value of this array key item
-					set(y, [{ _key: key }, 'y'])
-				)
-			)
-		},
-		[value]
-	)
+  const handleHotspotMove = React.useCallback(
+    (key, x, y) => {
+      if (!Number(x) || !Number(y)) {
+        console.warn(`Missing or non-number X or Y`, {x, y})
+        return
+      }
 
-	const hotspotImageRef = useRef<HTMLImageElement | null>(null)
+      onChange(
+        PatchEvent.from(
+          // Set the `x` value of this array key item
+          set(x, [{_key: key}, 'x']),
+          // Set the `y` value of this array key item
+          set(y, [{_key: key}, 'y'])
+        )
+      )
+    },
+    [value]
+  )
 
-	const [imageRect, setImageRect] = useState<DOMRectReadOnly>()
-	const updateImageRectCallback = useDebouncedCallback(((e) => setImageRect(e.contentRect)) as IUseResizeObserverCallback, [setImageRect], 200)
-	useResizeObserver(hotspotImageRef, updateImageRectCallback)
+  const hotspotImageRef = React.useRef(null)
 
-	return (
-		<Stack space={[2, 2, 3]}>
-			{displayImage?.url ? (
-				<div style={{ position: `relative` }}>
-					{imageRect && value?.length > 0 && value.map((spot) => <Spot key={spot._key} spot={spot} bounds={imageRect} update={handleHotspotMove} hotspotDescriptionPath={options?.hotspotDescriptionPath} tooltip={options?.hotspotTooltip} />)}
+  return (
+    <Stack space={[2,2,3]}>
+      {displayImage?.url ? (
+        <div style={{position: `relative`}}>
+          {value?.length > 0 &&
+            value.map((spot) => (
+              <Spot
+                key={spot._key}
+                spot={spot}
+                bounds={hotspotImageRef}
+                update={handleHotspotMove}
+                hotspotDescriptionPath={options?.hotspotDescriptionPath}
+                tooltip={options?.hotspotTooltip}
+              />
+            ))}
 
-					<Card __unstable_checkered shadow={1}>
-						<Flex align="center" justify="center">
-							<img ref={hotspotImageRef} src={displayImage.url} width={displayImage.width} height={displayImage.height} alt="" style={imageStyle} onClick={handleHotspotImageClick} />
-						</Flex>
-					</Card>
-				</div>
-			) : (
-				<Feedback>
-					{type?.options?.hotspotImagePath ? (
-						<>
-							No Hotspot image found at path <code>{type?.options?.hotspotImagePath}</code>
-						</>
-					) : (
-						<>
-							Define a path in this field using to the image field in this document at <code>options.hotspotImagePath</code>
-						</>
-					)}
-				</Feedback>
-			)}
-			{type?.options?.imageHotspotPathRoot && !VALID_ROOT_PATHS.includes(type.options.imageHotspotPathRoot) && (
-				<Feedback>
-					The supplied imageHotspotPathRoot "{type.options.imageHotspotPathRoot}" is not valid, falling back to "document". Available values are "{VALID_ROOT_PATHS.join(', ')}".
-				</Feedback>
-			)}
-			<FormBuilderInput {...props} type={typeWithoutInputComponent} ref={ref} />
-		</Stack>
-	)
+          <Card __unstable_checkered shadow={1}>
+            <Flex align="center" justify="center">
+              <img
+                ref={hotspotImageRef}
+                src={displayImage.url}
+                width={displayImage.width}
+                height={displayImage.height}
+                alt=""
+                style={imageStyle}
+                onClick={handleHotspotImageClick}
+                />
+            </Flex>
+          </Card>
+        </div>
+      ) : (
+        <Feedback>
+            {type?.options?.hotspotImagePath
+              ? <>No Hotspot image found at path <code>{type?.options?.hotspotImagePath}</code></>
+              : <>Define a path in this field using to the image field in this document at <code>options.hotspotImagePath</code></>
+            }
+          </Feedback>
+      )}
+        {type?.options?.imageHotspotPathRoot && !VALID_ROOT_PATHS.includes(type.options.imageHotspotPathRoot) &&
+        <Feedback>
+            The supplied imageHotspotPathRoot "{type.options.imageHotspotPathRoot}" is not valid, falling back to "document". Available values are "{VALID_ROOT_PATHS.join(', ')}".
+        </Feedback>}
+      <FormBuilderInput {...props} type={typeWithoutInputComponent} ref={ref} />
+    </Stack>
+  )
 })
 
 export default withDocument(HotspotArray)

--- a/src/HotspotArray.tsx
+++ b/src/HotspotArray.tsx
@@ -30,7 +30,7 @@ export type TSpot = {
   _type: `spot`
   x: number
   y: number
-} & { [key: string]: unknown }
+} & {[key: string]: unknown}
 
 const HotspotArray = React.forwardRef((props: any, ref) => {
   const {type, value, onChange, document, parent} = props
@@ -39,7 +39,13 @@ const HotspotArray = React.forwardRef((props: any, ref) => {
   // Attempt prevention of infinite loop in <FormBuilderInput />
   // Re-renders can still occur if this Component is used again in a nested field
   const typeWithoutInputComponent = useUnsetInputComponent(type, type?.inputComponent)
-  const imageHotspotPathRoot = React.useMemo(() => (VALID_ROOT_PATHS.includes(options?.imageHotspotPathRoot) ? props[options.imageHotspotPathRoot] : document), [])
+  const imageHotspotPathRoot = React.useMemo(
+    () =>
+      VALID_ROOT_PATHS.includes(options?.imageHotspotPathRoot)
+        ? props[options.imageHotspotPathRoot]
+        : document,
+    []
+  )
 
   // Finding the image from the imageHotspotPathRoot (defaults to document),
   // using the path from the hotspot's `options` field
@@ -105,14 +111,19 @@ const HotspotArray = React.forwardRef((props: any, ref) => {
   const hotspotImageRef = React.useRef<HTMLImageElement | null>(null)
 
   const [imageRect, setImageRect] = useState<DOMRectReadOnly>()
-  const updateImageRectCallback = useDebouncedCallback(((e) => setImageRect(e.contentRect)) as IUseResizeObserverCallback, [setImageRect], 200)
+  const updateImageRectCallback = useDebouncedCallback(
+    ((e) => setImageRect(e.contentRect)) as IUseResizeObserverCallback,
+    [setImageRect],
+    200
+  )
   useResizeObserver(hotspotImageRef, updateImageRectCallback)
 
   return (
-    <Stack space={[2,2,3]}>
+    <Stack space={[2, 2, 3]}>
       {displayImage?.url ? (
         <div style={{position: `relative`}}>
-          {imageRect && value?.length > 0 &&
+          {imageRect &&
+            value?.length > 0 &&
             value.map((spot) => (
               <Spot
                 key={spot._key}
@@ -134,22 +145,31 @@ const HotspotArray = React.forwardRef((props: any, ref) => {
                 alt=""
                 style={imageStyle}
                 onClick={handleHotspotImageClick}
-                />
+              />
             </Flex>
           </Card>
         </div>
       ) : (
         <Feedback>
-            {type?.options?.hotspotImagePath
-              ? <>No Hotspot image found at path <code>{type?.options?.hotspotImagePath}</code></>
-              : <>Define a path in this field using to the image field in this document at <code>options.hotspotImagePath</code></>
-            }
-          </Feedback>
+          {type?.options?.hotspotImagePath ? (
+            <>
+              No Hotspot image found at path <code>{type?.options?.hotspotImagePath}</code>
+            </>
+          ) : (
+            <>
+              Define a path in this field using to the image field in this document at{' '}
+              <code>options.hotspotImagePath</code>
+            </>
+          )}
+        </Feedback>
       )}
-        {type?.options?.imageHotspotPathRoot && !VALID_ROOT_PATHS.includes(type.options.imageHotspotPathRoot) &&
-        <Feedback>
-            The supplied imageHotspotPathRoot "{type.options.imageHotspotPathRoot}" is not valid, falling back to "document". Available values are "{VALID_ROOT_PATHS.join(', ')}".
-        </Feedback>}
+      {type?.options?.imageHotspotPathRoot &&
+        !VALID_ROOT_PATHS.includes(type.options.imageHotspotPathRoot) && (
+          <Feedback>
+            The supplied imageHotspotPathRoot "{type.options.imageHotspotPathRoot}" is not valid,
+            falling back to "document". Available values are "{VALID_ROOT_PATHS.join(', ')}".
+          </Feedback>
+        )}
       <FormBuilderInput {...props} type={typeWithoutInputComponent} ref={ref} />
     </Stack>
   )

--- a/src/HotspotArray.tsx
+++ b/src/HotspotArray.tsx
@@ -3,142 +3,139 @@
 // @ts-ignore
 import sanityClient from 'part:@sanity/base/client'
 // @ts-ignore
-import {withDocument} from 'part:@sanity/form-builder'
+import { withDocument } from 'part:@sanity/form-builder'
 
-import React from 'react'
-import {Card, Flex, Stack, Text} from '@sanity/ui'
-import {FormBuilderInput} from '@sanity/form-builder/lib/FormBuilderInput'
-import {randomKey} from '@sanity/util/content'
-import {PatchEvent, setIfMissing, set, insert} from '@sanity/form-builder/PatchEvent'
+import { IUseResizeObserverCallback, useDebouncedCallback, useResizeObserver } from '@react-hookz/web'
+import { getImageDimensions } from '@sanity/asset-utils'
+import { FormBuilderInput } from '@sanity/form-builder/lib/FormBuilderInput'
+import { insert, PatchEvent, set, setIfMissing } from '@sanity/form-builder/PatchEvent'
 import imageUrlBuilder from '@sanity/image-url'
-import {getImageDimensions} from '@sanity/asset-utils'
+import { Card, Flex, Stack } from '@sanity/ui'
+import { randomKey } from '@sanity/util/content'
 import get from 'lodash/get'
+import React, { useCallback, useRef, useState } from 'react'
 
+import Feedback from './Feedback'
 import Spot from './Spot'
 import { useUnsetInputComponent } from './useUnsetInputComponent'
-import Feedback from './Feedback'
 
-const imageStyle = {width: `100%`, height: `auto`}
+const imageStyle = { width: `100%`, height: `auto` }
 
 const VALID_ROOT_PATHS = ['document', 'parent']
 
-const HotspotArray = React.forwardRef((props, ref) => {
-  const {type, value, onChange, document, parent} = props
-  const {options} = type ?? {}
+export type FnHotspotMove = (key: string, x: number, y: number) => void
+
+export type TSpot = {
+	_key: string
+	_type: `spot`
+	x: number
+	y: number
+} & { [key: string]: unknown }
+
+const HotspotArray = React.forwardRef((props: any, ref) => {
+	const { type, value, onChange, document } = props
+	const { options } = type ?? {}
 
   // Attempt prevention of infinite loop in <FormBuilderInput />
-  // Re-renders can still occur if this Component is used again in a nested field
-  const typeWithoutInputComponent = useUnsetInputComponent(type, type?.inputComponent)
+	// Re-renders can still occur if this Component is used again in a nested field
+	const typeWithoutInputComponent = useUnsetInputComponent(type, type?.inputComponent)
+	const imageHotspotPathRoot = React.useMemo(() => (VALID_ROOT_PATHS.includes(options?.imageHotspotPathRoot) ? props[options.imageHotspotPathRoot] : document), [])
 
-  // Finding the image from the imageHotspotPathRoot (defaults to document),
-  // using the path from the hotspot's `options` field
-  const displayImage = React.useMemo(() => {
-    const builder = imageUrlBuilder(sanityClient).dataset(sanityClient.config().dataset)
-    const urlFor = (source) => builder.image(source)
+	// Finding the image from the imageHotspotPathRoot (defaults to document),
+	// using the path from the hotspot's `options` field
+	const displayImage = React.useMemo(() => {
+		const builder = imageUrlBuilder(sanityClient).dataset(sanityClient.config().dataset)
+		const urlFor = (source) => builder.image(source)
 
-    const imageHotspotPathRoot = VALID_ROOT_PATHS.includes(options?.imageHotspotPathRoot) ? props[options.imageHotspotPathRoot] : document
-    const hotspotImage = get(imageHotspotPathRoot, options?.hotspotImagePath)
+		const hotspotImage = get(imageHotspotPathRoot, options?.hotspotImagePath)
 
-    if (hotspotImage?.asset?._ref) {
-      const {aspectRatio} = getImageDimensions(hotspotImage.asset._ref)
-      const width = 600
-      const height = Math.round(width / aspectRatio)
-      const url = urlFor(hotspotImage).width(width).url()
+		if (hotspotImage?.asset?._ref) {
+			const { aspectRatio } = getImageDimensions(hotspotImage.asset._ref)
+			const width = 600
+			const height = Math.round(width / aspectRatio)
+			const url = urlFor(hotspotImage).width(width).url()
 
-      return {width, height, url}
-    }
+			return { width, height, url }
+		}
 
-    return null
-  }, [type, document])
+		return null
+	}, [type, imageHotspotPathRoot])
 
-  const handleHotspotImageClick = React.useCallback((event) => {
-    const {nativeEvent} = event
+	const handleHotspotImageClick = React.useCallback((event) => {
+		const { nativeEvent } = event
 
-    // Calculate the x/y percentage of the click position
-    const x = Number(((nativeEvent.offsetX * 100) / nativeEvent.srcElement.width).toFixed(2))
-    const y = Number(((nativeEvent.offsetY * 100) / nativeEvent.srcElement.height).toFixed(2))
-    const description = `New Hotspot at ${x}% x ${y}%`
+		// Calculate the x/y percentage of the click position
+		const x = Number(((nativeEvent.offsetX * 100) / nativeEvent.srcElement.width).toFixed(2))
+		const y = Number(((nativeEvent.offsetY * 100) / nativeEvent.srcElement.height).toFixed(2))
+		const description = `New Hotspot at ${x}% x ${y}%`
 
-    const newRow = {
-      _key: randomKey(12),
-      _type: `spot`,
-      x,
-      y,
-    }
+		const newRow: TSpot = {
+			_key: randomKey(12),
+			_type: `spot`,
+			x,
+			y,
+		}
 
-    if (options?.hotspotDescriptionPath) {
-      newRow[options.hotspotDescriptionPath] = description
-    }
+		if (options?.hotspotDescriptionPath) {
+			newRow[options.hotspotDescriptionPath] = description
+		}
 
-    onChange(PatchEvent.from(setIfMissing([]), insert([newRow], 'after', [-1])))
-  }, [])
+		onChange(PatchEvent.from(setIfMissing([]), insert([newRow], 'after', [-1])))
+	}, [])
 
-  const handleHotspotMove = React.useCallback(
-    (key, x, y) => {
-      if (!Number(x) || !Number(y)) {
-        console.warn(`Missing or non-number X or Y`, {x, y})
-        return
-      }
+	const handleHotspotMove: FnHotspotMove = useCallback(
+		(key, x, y) => {
+			onChange(
+				PatchEvent.from(
+					// Set the `x` value of this array key item
+					set(x, [{ _key: key }, 'x']),
+					// Set the `y` value of this array key item
+					set(y, [{ _key: key }, 'y'])
+				)
+			)
+		},
+		[value]
+	)
 
-      onChange(
-        PatchEvent.from(
-          // Set the `x` value of this array key item
-          set(x, [{_key: key}, 'x']),
-          // Set the `y` value of this array key item
-          set(y, [{_key: key}, 'y'])
-        )
-      )
-    },
-    [value]
-  )
+	const hotspotImageRef = useRef<HTMLImageElement | null>(null)
 
-  const hotspotImageRef = React.useRef(null)
+	const [imageRect, setImageRect] = useState<DOMRectReadOnly>()
+	const updateImageRectCallback = useDebouncedCallback(((e) => setImageRect(e.contentRect)) as IUseResizeObserverCallback, [setImageRect], 200)
+	useResizeObserver(hotspotImageRef, updateImageRectCallback)
 
-  return (
-    <Stack space={[2,2,3]}>
-      {displayImage?.url ? (
-        <div style={{position: `relative`}}>
-          {value?.length > 0 &&
-            value.map((spot) => (
-              <Spot
-                key={spot._key}
-                spot={spot}
-                bounds={hotspotImageRef}
-                update={handleHotspotMove}
-                hotspotDescriptionPath={options?.hotspotDescriptionPath}
-                tooltip={options?.hotspotTooltip}
-              />
-            ))}
+	return (
+		<Stack space={[2, 2, 3]}>
+			{displayImage?.url ? (
+				<div style={{ position: `relative` }}>
+					{imageRect && value?.length > 0 && value.map((spot) => <Spot key={spot._key} spot={spot} bounds={imageRect} update={handleHotspotMove} hotspotDescriptionPath={options?.hotspotDescriptionPath} tooltip={options?.hotspotTooltip} />)}
 
-          <Card __unstable_checkered shadow={1}>
-            <Flex align="center" justify="center">
-              <img
-                ref={hotspotImageRef}
-                src={displayImage.url}
-                width={displayImage.width}
-                height={displayImage.height}
-                alt=""
-                style={imageStyle}
-                onClick={handleHotspotImageClick}
-                />
-            </Flex>
-          </Card>
-        </div>
-      ) : (
-        <Feedback>
-            {type?.options?.hotspotImagePath
-              ? <>No Hotspot image found at path <code>{type?.options?.hotspotImagePath}</code></>
-              : <>Define a path in this field using to the image field in this document at <code>options.hotspotImagePath</code></>
-            }
-          </Feedback>
-      )}
-        {type?.options?.imageHotspotPathRoot && !VALID_ROOT_PATHS.includes(type.options.imageHotspotPathRoot) &&
-        <Feedback>
-            The supplied imageHotspotPathRoot "{type.options.imageHotspotPathRoot}" is not valid, falling back to "document". Available values are "{VALID_ROOT_PATHS.join(', ')}".
-        </Feedback>}
-      <FormBuilderInput {...props} type={typeWithoutInputComponent} ref={ref} />
-    </Stack>
-  )
+					<Card __unstable_checkered shadow={1}>
+						<Flex align="center" justify="center">
+							<img ref={hotspotImageRef} src={displayImage.url} width={displayImage.width} height={displayImage.height} alt="" style={imageStyle} onClick={handleHotspotImageClick} />
+						</Flex>
+					</Card>
+				</div>
+			) : (
+				<Feedback>
+					{type?.options?.hotspotImagePath ? (
+						<>
+							No Hotspot image found at path <code>{type?.options?.hotspotImagePath}</code>
+						</>
+					) : (
+						<>
+							Define a path in this field using to the image field in this document at <code>options.hotspotImagePath</code>
+						</>
+					)}
+				</Feedback>
+			)}
+			{type?.options?.imageHotspotPathRoot && !VALID_ROOT_PATHS.includes(type.options.imageHotspotPathRoot) && (
+				<Feedback>
+					The supplied imageHotspotPathRoot "{type.options.imageHotspotPathRoot}" is not valid, falling back to "document". Available values are "{VALID_ROOT_PATHS.join(', ')}".
+				</Feedback>
+			)}
+			<FormBuilderInput {...props} type={typeWithoutInputComponent} ref={ref} />
+		</Stack>
+	)
 })
 
 export default withDocument(HotspotArray)

--- a/src/Spot.tsx
+++ b/src/Spot.tsx
@@ -98,7 +98,7 @@ export default function Spot({spot, bounds, update, hotspotDescriptionPath = ``,
           React.createElement(tooltip, {spot})
         ) : (
           <Box padding={2} style={{maxWidth: 200, pointerEvents: `none`}}>
-            <Text textOverflow="ellipsis">{hotspotDescriptionPath ? get(spot, hotspotDescriptionPath) : `${spot.x}% x ${spot.y}%`}</Text>
+            <Text textOverflow="ellipsis">{hotspotDescriptionPath ? get(spot, hotspotDescriptionPath) as string : `${spot.x}% x ${spot.y}%`}</Text>
           </Box>
         )
       }

--- a/src/Spot.tsx
+++ b/src/Spot.tsx
@@ -112,6 +112,7 @@ export default function Spot({spot, bounds = undefined, update, hotspotDescripti
       <motion.div
         drag
         dragConstraints={bounds}
+        dragElastic={0}
         dragMomentum={false}
         initial={{x, y}}
         onDragEnd={handleDragEnd}

--- a/src/Spot.tsx
+++ b/src/Spot.tsx
@@ -1,7 +1,7 @@
-import React from 'react'
-import {Box, Card, Text, Tooltip} from '@sanity/ui'
-import {motion} from 'framer-motion'
+import { Box, Card, Text, Tooltip } from '@sanity/ui'
+import { motion } from 'framer-motion'
 import get from 'lodash/get'
+import React from 'react'
 
 const dragStyle = {
   width: `1rem`,
@@ -66,7 +66,7 @@ export default function Spot({spot, bounds = undefined, update, hotspotDescripti
       // Which we need to convert back to `%` to patch the document
       const newX = round((currentX * 100) / rect.width)
       const newY = round((currentY * 100) / rect.height)
-      
+
       // Don't go below 0 or above 100
       const safeX = Math.max(0, Math.min(100, newX))
       const safeY = Math.max(0, Math.min(100, newY))

--- a/src/Spot.tsx
+++ b/src/Spot.tsx
@@ -40,7 +40,7 @@ interface IHotspot {
   tooltip?: ReactElement
 }
 
-export default function Spot({spot, bounds, update, hotspotDescriptionPath = ``, tooltip}: IHotspot) {
+export default function Spot({spot, bounds, update, hotspotDescriptionPath, tooltip}: IHotspot) {
   const [isDragging, setIsDragging] = React.useState(false)
   // x/y are stored as % but need to be converted to px
   const x = useMotionValue(round(bounds.width * (spot.x / 100)))
@@ -49,7 +49,7 @@ export default function Spot({spot, bounds, update, hotspotDescriptionPath = ``,
   /**
    * update x/y if the bounds change when resizing the window
    */
-   useEffect(() => {
+  useEffect(() => {
     x.set(round(bounds.width * (spot.x / 100)))
     y.set(round(bounds.height * (spot.y / 100)))
   }, [bounds])
@@ -67,7 +67,7 @@ export default function Spot({spot, bounds, update, hotspotDescriptionPath = ``,
       }
 
       if (!bounds.width || !bounds.height) {
-        return console.warn(`Rect width/height not yet set`, { bounds })
+        return console.warn(`Rect width/height not yet set`, {bounds})
       }
 
       // Which we need to convert back to `%` to patch the document
@@ -98,7 +98,11 @@ export default function Spot({spot, bounds, update, hotspotDescriptionPath = ``,
           React.createElement(tooltip, {spot})
         ) : (
           <Box padding={2} style={{maxWidth: 200, pointerEvents: `none`}}>
-            <Text textOverflow="ellipsis">{hotspotDescriptionPath ? get(spot, hotspotDescriptionPath) as string : `${spot.x}% x ${spot.y}%`}</Text>
+            <Text textOverflow="ellipsis">
+              {hotspotDescriptionPath
+                ? (get(spot, hotspotDescriptionPath) as string)
+                : `${spot.x}% x ${spot.y}%`}
+            </Text>
           </Box>
         )
       }
@@ -110,7 +114,7 @@ export default function Spot({spot, bounds, update, hotspotDescriptionPath = ``,
         dragMomentum={false}
         onDragEnd={handleDragEnd}
         onDragStart={() => setIsDragging(true)}
-        style={isDragging ? { ...dragStyle, ...dragStyleWhileDrag, x, y } : { ...dragStyle, x, y }}
+        style={isDragging ? {...dragStyle, ...dragStyleWhileDrag, x, y} : {...dragStyle, x, y}}
       >
         <Card tone="primary" shadow={3} style={dotStyle}>
           ・

--- a/src/Spot.tsx
+++ b/src/Spot.tsx
@@ -1,8 +1,8 @@
-import { Box, Card, Text, Tooltip } from '@sanity/ui'
-import { motion, useMotionValue } from 'framer-motion'
+import {Box, Card, Text, Tooltip} from '@sanity/ui'
+import {motion, useMotionValue} from 'framer-motion'
 import get from 'lodash/get'
-import React, { CSSProperties, ReactElement, useEffect } from 'react'
-import { FnHotspotMove, TSpot } from './HotspotArray'
+import React, {CSSProperties, ReactElement, useEffect} from 'react'
+import {FnHotspotMove, TSpot} from './HotspotArray'
 
 const dragStyle: CSSProperties = {
   width: '1rem',

--- a/src/Spot.tsx
+++ b/src/Spot.tsx
@@ -1,21 +1,33 @@
 import { Box, Card, Text, Tooltip } from '@sanity/ui'
 import { motion } from 'framer-motion'
 import get from 'lodash/get'
-import React from 'react'
+import React, { CSSProperties } from 'react'
 
-const dragStyle = {
-  width: `1rem`,
-  height: `1rem`,
-  position: `absolute`,
+const dragStyle: CSSProperties = {
+	width: '1rem',
+	height: '1rem',
+	position: 'absolute',
+	top: 0,
+	left: 0,
+	margin: '-0.5rem 0 0 -0.5rem',
+	cursor: 'pointer',
 }
 
-const dotStyle = {
-  ...dragStyle,
-  borderRadius: `50%`,
-  // make sure pointer events only run on the parent
-  pointerEvents: `none`,
+const dragStyleWhileDrag: CSSProperties = {
+	cursor: 'none',
 }
 
+const dotStyle: CSSProperties = {
+	width: 'inherit',
+	height: 'inherit',
+	borderRadius: '50%',
+	textAlign: 'center',
+	lineHeight: 1,
+	backgroundColor: 'rgba(255, 255, 255, 0.2)',
+	color: 'black',
+	// make sure pointer events only run on the parent
+	pointerEvents: 'none',
+}
 const round = (num) => Math.round(num * 100) / 100
 
 export default function Spot({spot, bounds = undefined, update, hotspotDescriptionPath = ``, tooltip}) {
@@ -104,9 +116,11 @@ export default function Spot({spot, bounds = undefined, update, hotspotDescripti
         initial={{x, y}}
         onDragEnd={handleDragEnd}
         onDragStart={() => setIsDragging(true)}
-        style={dragStyle}
+        style={isDragging ? { ...dragStyle, ...dragStyleWhileDrag, x, y } : { ...dragStyle, x, y }}
       >
-        <Card tone="primary" shadow={3} style={dotStyle} />
+        <Card tone="primary" shadow={3} style={dotStyle}>
+          ・
+        </Card>
       </motion.div>
     </Tooltip>
   )

--- a/src/Spot.tsx
+++ b/src/Spot.tsx
@@ -54,27 +54,24 @@ export default function Spot({spot, bounds, update, hotspotDescriptionPath, tool
     y.set(round(bounds.height * (spot.y / 100)))
   }, [bounds])
 
-  const handleDragEnd = React.useCallback(
-    (event) => {
-      setIsDragging(false)
+  const handleDragEnd = React.useCallback(() => {
+    setIsDragging(false)
 
-      // get current values for x/y in px
-      const currentX = x.get()
-      const currentY = y.get()
+    // get current values for x/y in px
+    const currentX = x.get()
+    const currentY = y.get()
 
-      // Which we need to convert back to `%` to patch the document
-      const newX = round((currentX * 100) / bounds.width)
-      const newY = round((currentY * 100) / bounds.height)
+    // Which we need to convert back to `%` to patch the document
+    const newX = round((currentX * 100) / bounds.width)
+    const newY = round((currentY * 100) / bounds.height)
 
-      // Don't go below 0 or above 100
-      const safeX = Math.max(0, Math.min(100, newX))
-      const safeY = Math.max(0, Math.min(100, newY))
+    // Don't go below 0 or above 100
+    const safeX = Math.max(0, Math.min(100, newX))
+    const safeY = Math.max(0, Math.min(100, newY))
 
-      update(spot._key, safeX, safeY)
-    },
-
-    [spot]
-  )
+    update(spot._key, safeX, safeY)
+  }, [spot])
+  const handleDragStart = React.useCallback(() => setIsDragging(true), [])
 
   if (!x || !y) {
     return null
@@ -105,8 +102,13 @@ export default function Spot({spot, bounds, update, hotspotDescriptionPath, tool
         dragElastic={0}
         dragMomentum={false}
         onDragEnd={handleDragEnd}
-        onDragStart={() => setIsDragging(true)}
-        style={isDragging ? {...dragStyle, ...dragStyleWhileDrag, x, y} : {...dragStyle, x, y}}
+        onDragStart={handleDragStart}
+        style={{
+          ...dragStyle,
+          x,
+          y,
+          ...(isDragging && {...dragStyleWhileDrag}),
+        }}
       >
         <Card tone="primary" shadow={3} style={dotStyle}>
           ・

--- a/src/Spot.tsx
+++ b/src/Spot.tsx
@@ -62,14 +62,6 @@ export default function Spot({spot, bounds, update, hotspotDescriptionPath, tool
       const currentX = x.get()
       const currentY = y.get()
 
-      if (!Number(currentX) || !Number(currentY)) {
-        return console.warn(`Missing or non-number X or Y`, {currentX, currentY}, event.srcElement)
-      }
-
-      if (!bounds.width || !bounds.height) {
-        return console.warn(`Rect width/height not yet set`, {bounds})
-      }
-
       // Which we need to convert back to `%` to patch the document
       const newX = round((currentX * 100) / bounds.width)
       const newY = round((currentY * 100) / bounds.height)

--- a/src/Spot.tsx
+++ b/src/Spot.tsx
@@ -4,29 +4,29 @@ import get from 'lodash/get'
 import React, { CSSProperties } from 'react'
 
 const dragStyle: CSSProperties = {
-	width: '1rem',
-	height: '1rem',
-	position: 'absolute',
-	top: 0,
-	left: 0,
-	margin: '-0.5rem 0 0 -0.5rem',
-	cursor: 'pointer',
+  width: '1rem',
+  height: '1rem',
+  position: 'absolute',
+  top: 0,
+  left: 0,
+  margin: '-0.5rem 0 0 -0.5rem',
+  cursor: 'pointer',
 }
 
 const dragStyleWhileDrag: CSSProperties = {
-	cursor: 'none',
+  cursor: 'none',
 }
 
 const dotStyle: CSSProperties = {
-	width: 'inherit',
-	height: 'inherit',
-	borderRadius: '50%',
-	textAlign: 'center',
-	lineHeight: 1,
-	backgroundColor: 'rgba(255, 255, 255, 0.2)',
-	color: 'black',
-	// make sure pointer events only run on the parent
-	pointerEvents: 'none',
+  width: 'inherit',
+  height: 'inherit',
+  borderRadius: '50%',
+  textAlign: 'center',
+  lineHeight: 1,
+  backgroundColor: 'rgba(255, 255, 255, 0.2)',
+  color: 'black',
+  // make sure pointer events only run on the parent
+  pointerEvents: 'none',
 }
 
 const round = (num) => Math.round(num * 100) / 100

--- a/src/Spot.tsx
+++ b/src/Spot.tsx
@@ -1,113 +1,106 @@
-import React from 'react'
-import {Box, Card, Text, Tooltip} from '@sanity/ui'
-import {motion} from 'framer-motion'
+import { Box, Card, Text, Tooltip } from '@sanity/ui'
+import { motion, useMotionValue } from 'framer-motion'
 import get from 'lodash/get'
+import { createElement, CSSProperties, ReactElement, useCallback, useEffect, useState } from 'react'
+import { FnHotspotMove, TSpot } from './HotspotArray'
+import React from 'react'
 
-const dragStyle = {
-  width: `1rem`,
-  height: `1rem`,
-  position: `absolute`,
+const dragStyle: CSSProperties = {
+	width: '1rem',
+	height: '1rem',
+	position: 'absolute',
+	top: 0,
+	left: 0,
+	margin: '-0.5rem 0 0 -0.5rem',
+	cursor: 'pointer',
 }
 
-const dotStyle = {
-  ...dragStyle,
-  borderRadius: `50%`,
-  // make sure pointer events only run on the parent
-  pointerEvents: `none`,
+const dragStyleWhileDrag: CSSProperties = {
+	cursor: 'none',
+}
+
+const dotStyle: CSSProperties = {
+	width: 'inherit',
+	height: 'inherit',
+	borderRadius: '50%',
+	textAlign: 'center',
+	lineHeight: 1,
+	backgroundColor: 'rgba(255, 255, 255, 0.2)',
+	color: 'black',
+	// make sure pointer events only run on the parent
+	pointerEvents: 'none',
 }
 
 const round = (num) => Math.round(num * 100) / 100
 
-export default function Spot({spot, bounds = undefined, update, hotspotDescriptionPath = ``, tooltip}) {
-  // x/y are stored as % but need to be displayed as px
-  const [{x, y}, setXY] = React.useState({x: 0, y: 0})
-  const [rect, setRect] = React.useState(bounds?.current ? bounds.current.getBoundingClientRect() : {width: 0, height:0})
-  const [isDragging, setIsDragging] = React.useState(false)
+interface IHotspot {
+	spot: TSpot
+	bounds: DOMRectReadOnly
+	update: FnHotspotMove
+	hotspotDescriptionPath?: string
+	tooltip?: ReactElement
+}
 
-  React.useEffect(() => {
-    const clientRect = bounds?.current?.getBoundingClientRect()
+export default function Spot({ spot, bounds, update, hotspotDescriptionPath, tooltip }: IHotspot) {
+	const [isDragging, setIsDragging] = useState(false)
+	// x/y are stored as % but need to be converted to px
+	const x = useMotionValue(round(bounds.width * (spot.x / 100)))
+	const y = useMotionValue(round(bounds.height * (spot.y / 100)))
 
-    if (clientRect) {
-      // So convert % to px once we know the height/width of the image
-      setXY({
-        x: round(clientRect.width * (spot.x / 100)),
-        y: round(clientRect.height * (spot.y / 100)),
-      })
+	/**
+	 * update x/y if the bounds change when resizing the window
+	 */
+	useEffect(() => {
+		x.set(round(bounds.width * (spot.x / 100)))
+		y.set(round(bounds.height * (spot.y / 100)))
+	}, [bounds])
 
-      if (!rect.width || !rect.height) {
-        setRect(clientRect)
-      }
-    }
-  }, [bounds, bounds.current])
+	const handleDragEnd = useCallback(() => {
+		setIsDragging(false)
 
-  const handleDragEnd = React.useCallback(
-    (event) => {
-      setIsDragging(false)
+		// get current values for x/y in px
+		const currentX = x.get()
+		const currentY = y.get()
 
-      // I don't know why, but framer-motion doesn't give you the actual transform values
-      // So we have to regex the `px` values off the inline styles
-      const [currentX, currentY] = event.srcElement.style.transform.split(` `).map((v) => {
-        return v
-          ? v
-              .match(/\(([^)]+)\)/)
-              .pop()
-              .replace(`px`, ``)
-          : null
-      })
+		if (!bounds.width || !bounds.height) {
+			return console.warn(`Rect width/height not yet set`, { bounds })
+		}
 
-      if (!Number(currentX) || !Number(currentY)) {
-        return console.warn(`Missing or non-number X or Y`, {currentX, currentY}, event.srcElement)
-      }
+		// convert back to `%` to patch the document
+		const newX = round((currentX * 100) / bounds.width)
+		const newY = round((currentY * 100) / bounds.height)
 
-      if (!rect.width || !rect.height) {
-        return console.warn(`Rect width/height not yet set`, {rect}, bounds?.current)
-      }
+		// don't go below 0 or above 100
+		const safeX = Math.max(0, Math.min(100, newX))
+		const safeY = Math.max(0, Math.min(100, newY))
 
-      // Which we need to convert back to `%` to patch the document
-      const newX = round((currentX * 100) / rect.width)
-      const newY = round((currentY * 100) / rect.height)
-      
-      // Don't go below 0 or above 100
-      const safeX = Math.max(0, Math.min(100, newX))
-      const safeY = Math.max(0, Math.min(100, newY))
+		update(spot._key, safeX, safeY)
+	}, [spot])
 
-      update(spot._key, safeX, safeY)
-    },
+	if (!x || !y) {
+		return null
+	}
 
-    [spot]
-  )
-
-  if (!x || !y) {
-    return null
-  }
-
-  return (
-    <Tooltip
-      key={spot._key}
-      disabled={isDragging}
-      boundaryElement={bounds.current}
-      portal
-      content={
-        tooltip && typeof tooltip === 'function' ? (
-          React.createElement(tooltip, {spot})
-        ) : (
-          <Box padding={2} style={{maxWidth: 200, pointerEvents: `none`}}>
-            <Text textOverflow="ellipsis">{hotspotDescriptionPath ? get(spot, hotspotDescriptionPath) : `${spot.x}% x ${spot.y}%`}</Text>
-          </Box>
-        )
-      }
-    >
-      <motion.div
-        drag
-        dragConstraints={bounds}
-        dragMomentum={false}
-        initial={{x, y}}
-        onDragEnd={handleDragEnd}
-        onDragStart={() => setIsDragging(true)}
-        style={dragStyle}
-      >
-        <Card tone="primary" shadow={3} style={dotStyle} />
-      </motion.div>
-    </Tooltip>
-  )
+	return (
+		<Tooltip
+			key={spot._key}
+			disabled={isDragging}
+			portal
+			content={
+				tooltip && typeof tooltip === 'function' ? (
+					createElement(tooltip, { spot })
+				) : (
+					<Box padding={2} style={{ maxWidth: 200, pointerEvents: `none` }}>
+						<Text textOverflow="ellipsis">{hotspotDescriptionPath ? get(spot, hotspotDescriptionPath) as string : `${spot.x}% x ${spot.y}%`}</Text>
+					</Box>
+				)
+			}
+		>
+			<motion.div drag dragConstraints={bounds} dragElastic={0} dragMomentum={false} onDragEnd={handleDragEnd} onDragStart={() => setIsDragging(true)} style={isDragging ? { ...dragStyle, ...dragStyleWhileDrag, x, y } : { ...dragStyle, x, y }}>
+				<Card tone="primary" shadow={3} style={dotStyle}>
+					・
+				</Card>
+			</motion.div>
+		</Tooltip>
+	)
 }

--- a/src/Spot.tsx
+++ b/src/Spot.tsx
@@ -1,106 +1,113 @@
-import { Box, Card, Text, Tooltip } from '@sanity/ui'
-import { motion, useMotionValue } from 'framer-motion'
-import get from 'lodash/get'
-import { createElement, CSSProperties, ReactElement, useCallback, useEffect, useState } from 'react'
-import { FnHotspotMove, TSpot } from './HotspotArray'
 import React from 'react'
+import {Box, Card, Text, Tooltip} from '@sanity/ui'
+import {motion} from 'framer-motion'
+import get from 'lodash/get'
 
-const dragStyle: CSSProperties = {
-	width: '1rem',
-	height: '1rem',
-	position: 'absolute',
-	top: 0,
-	left: 0,
-	margin: '-0.5rem 0 0 -0.5rem',
-	cursor: 'pointer',
+const dragStyle = {
+  width: `1rem`,
+  height: `1rem`,
+  position: `absolute`,
 }
 
-const dragStyleWhileDrag: CSSProperties = {
-	cursor: 'none',
-}
-
-const dotStyle: CSSProperties = {
-	width: 'inherit',
-	height: 'inherit',
-	borderRadius: '50%',
-	textAlign: 'center',
-	lineHeight: 1,
-	backgroundColor: 'rgba(255, 255, 255, 0.2)',
-	color: 'black',
-	// make sure pointer events only run on the parent
-	pointerEvents: 'none',
+const dotStyle = {
+  ...dragStyle,
+  borderRadius: `50%`,
+  // make sure pointer events only run on the parent
+  pointerEvents: `none`,
 }
 
 const round = (num) => Math.round(num * 100) / 100
 
-interface IHotspot {
-	spot: TSpot
-	bounds: DOMRectReadOnly
-	update: FnHotspotMove
-	hotspotDescriptionPath?: string
-	tooltip?: ReactElement
-}
+export default function Spot({spot, bounds = undefined, update, hotspotDescriptionPath = ``, tooltip}) {
+  // x/y are stored as % but need to be displayed as px
+  const [{x, y}, setXY] = React.useState({x: 0, y: 0})
+  const [rect, setRect] = React.useState(bounds?.current ? bounds.current.getBoundingClientRect() : {width: 0, height:0})
+  const [isDragging, setIsDragging] = React.useState(false)
 
-export default function Spot({ spot, bounds, update, hotspotDescriptionPath, tooltip }: IHotspot) {
-	const [isDragging, setIsDragging] = useState(false)
-	// x/y are stored as % but need to be converted to px
-	const x = useMotionValue(round(bounds.width * (spot.x / 100)))
-	const y = useMotionValue(round(bounds.height * (spot.y / 100)))
+  React.useEffect(() => {
+    const clientRect = bounds?.current?.getBoundingClientRect()
 
-	/**
-	 * update x/y if the bounds change when resizing the window
-	 */
-	useEffect(() => {
-		x.set(round(bounds.width * (spot.x / 100)))
-		y.set(round(bounds.height * (spot.y / 100)))
-	}, [bounds])
+    if (clientRect) {
+      // So convert % to px once we know the height/width of the image
+      setXY({
+        x: round(clientRect.width * (spot.x / 100)),
+        y: round(clientRect.height * (spot.y / 100)),
+      })
 
-	const handleDragEnd = useCallback(() => {
-		setIsDragging(false)
+      if (!rect.width || !rect.height) {
+        setRect(clientRect)
+      }
+    }
+  }, [bounds, bounds.current])
 
-		// get current values for x/y in px
-		const currentX = x.get()
-		const currentY = y.get()
+  const handleDragEnd = React.useCallback(
+    (event) => {
+      setIsDragging(false)
 
-		if (!bounds.width || !bounds.height) {
-			return console.warn(`Rect width/height not yet set`, { bounds })
-		}
+      // I don't know why, but framer-motion doesn't give you the actual transform values
+      // So we have to regex the `px` values off the inline styles
+      const [currentX, currentY] = event.srcElement.style.transform.split(` `).map((v) => {
+        return v
+          ? v
+              .match(/\(([^)]+)\)/)
+              .pop()
+              .replace(`px`, ``)
+          : null
+      })
 
-		// convert back to `%` to patch the document
-		const newX = round((currentX * 100) / bounds.width)
-		const newY = round((currentY * 100) / bounds.height)
+      if (!Number(currentX) || !Number(currentY)) {
+        return console.warn(`Missing or non-number X or Y`, {currentX, currentY}, event.srcElement)
+      }
 
-		// don't go below 0 or above 100
-		const safeX = Math.max(0, Math.min(100, newX))
-		const safeY = Math.max(0, Math.min(100, newY))
+      if (!rect.width || !rect.height) {
+        return console.warn(`Rect width/height not yet set`, {rect}, bounds?.current)
+      }
 
-		update(spot._key, safeX, safeY)
-	}, [spot])
+      // Which we need to convert back to `%` to patch the document
+      const newX = round((currentX * 100) / rect.width)
+      const newY = round((currentY * 100) / rect.height)
+      
+      // Don't go below 0 or above 100
+      const safeX = Math.max(0, Math.min(100, newX))
+      const safeY = Math.max(0, Math.min(100, newY))
 
-	if (!x || !y) {
-		return null
-	}
+      update(spot._key, safeX, safeY)
+    },
 
-	return (
-		<Tooltip
-			key={spot._key}
-			disabled={isDragging}
-			portal
-			content={
-				tooltip && typeof tooltip === 'function' ? (
-					createElement(tooltip, { spot })
-				) : (
-					<Box padding={2} style={{ maxWidth: 200, pointerEvents: `none` }}>
-						<Text textOverflow="ellipsis">{hotspotDescriptionPath ? get(spot, hotspotDescriptionPath) as string : `${spot.x}% x ${spot.y}%`}</Text>
-					</Box>
-				)
-			}
-		>
-			<motion.div drag dragConstraints={bounds} dragElastic={0} dragMomentum={false} onDragEnd={handleDragEnd} onDragStart={() => setIsDragging(true)} style={isDragging ? { ...dragStyle, ...dragStyleWhileDrag, x, y } : { ...dragStyle, x, y }}>
-				<Card tone="primary" shadow={3} style={dotStyle}>
-					・
-				</Card>
-			</motion.div>
-		</Tooltip>
-	)
+    [spot]
+  )
+
+  if (!x || !y) {
+    return null
+  }
+
+  return (
+    <Tooltip
+      key={spot._key}
+      disabled={isDragging}
+      boundaryElement={bounds.current}
+      portal
+      content={
+        tooltip && typeof tooltip === 'function' ? (
+          React.createElement(tooltip, {spot})
+        ) : (
+          <Box padding={2} style={{maxWidth: 200, pointerEvents: `none`}}>
+            <Text textOverflow="ellipsis">{hotspotDescriptionPath ? get(spot, hotspotDescriptionPath) : `${spot.x}% x ${spot.y}%`}</Text>
+          </Box>
+        )
+      }
+    >
+      <motion.div
+        drag
+        dragConstraints={bounds}
+        dragMomentum={false}
+        initial={{x, y}}
+        onDragEnd={handleDragEnd}
+        onDragStart={() => setIsDragging(true)}
+        style={dragStyle}
+      >
+        <Card tone="primary" shadow={3} style={dotStyle} />
+      </motion.div>
+    </Tooltip>
+  )
 }

--- a/src/Spot.tsx
+++ b/src/Spot.tsx
@@ -1,7 +1,8 @@
 import { Box, Card, Text, Tooltip } from '@sanity/ui'
 import { motion, useMotionValue } from 'framer-motion'
 import get from 'lodash/get'
-import React, { CSSProperties } from 'react'
+import React, { CSSProperties, ReactElement } from 'react'
+import { FnHotspotMove, TSpot } from './HotspotArray'
 
 const dragStyle: CSSProperties = {
   width: '1rem',
@@ -31,7 +32,15 @@ const dotStyle: CSSProperties = {
 
 const round = (num) => Math.round(num * 100) / 100
 
-export default function Spot({spot, bounds = undefined, update, hotspotDescriptionPath = ``, tooltip}) {
+interface IHotspot {
+  spot: TSpot
+  bounds: React.MutableRefObject<HTMLImageElement | null>
+  update: FnHotspotMove
+  hotspotDescriptionPath?: string
+  tooltip?: ReactElement
+}
+
+export default function Spot({spot, bounds, update, hotspotDescriptionPath = ``, tooltip}: IHotspot) {
   // x/y are stored as % but need to be converted to px
   const x = useMotionValue(0)
   const y = useMotionValue(0)

--- a/src/useUnsetInputComponent.ts
+++ b/src/useUnsetInputComponent.ts
@@ -3,7 +3,7 @@ import React from 'react'
 export function useUnsetInputComponent(type, component) {
     return React.useMemo(() => unsetInputComponent(type, component), [type, component])
   }
-  
+
   function unsetInputComponent(type, component) {
     const t = {
       ...type,

--- a/src/useUnsetInputComponent.ts
+++ b/src/useUnsetInputComponent.ts
@@ -1,17 +1,17 @@
 import React from 'react'
 
 export function useUnsetInputComponent(type, component) {
-    return React.useMemo(() => unsetInputComponent(type, component), [type, component])
-  }
+  return React.useMemo(() => unsetInputComponent(type, component), [type, component])
+}
 
-  function unsetInputComponent(type, component) {
-    const t = {
-      ...type,
-      inputComponent: type.inputComponent === component ? undefined : type.inputComponent,
-    }
-    const typeOfType = t.type ? unsetInputComponent(t.type, component) : undefined
-    return {
-      ...t,
-      type: typeOfType,
-    }
+function unsetInputComponent(type, component) {
+  const t = {
+    ...type,
+    inputComponent: type.inputComponent === component ? undefined : type.inputComponent,
   }
+  const typeOfType = t.type ? unsetInputComponent(t.type, component) : undefined
+  return {
+    ...t,
+    type: typeOfType,
+  }
+}


### PR DESCRIPTION
Hey @SimeonGriggs 👋 

I have made some more changes to the plugin. 

### Update dependencies
All dependencies are up-to-date now. Only React is still on 17. 

### Use framer motion to get x/y values
Instead of parsing the transform of the hotspot, framer motions' useMotionValue hook is used to get the correct value

### Allow changing hotspots after initial save
Before it was not possible to update hotspots after they where initially created, because the referenced imageRef did not exists in the DOM when the Spot components where created. And as refs do not trigger a re-render, the Spot components never knew about the image.
Simply switching the order of the Spot components and the image would have done the trick, but with the next change I was able to get rid of the imageRef altogether.

### Use DOMRect instead of ImageRef for bounds
The rectangle is tracked by a ResizeObserver and updates the bounds, when the browser window and image resizes. This way the hotspots are always correctly repositioned. The rect is also used to calculate the initial position of the hotspot. 

### Update hotspot styles 

- The hotspot is now semi-opaque and has a dot in the middle, to pinpoint the hotspot position. 
- The cursor is removed while dragging, so it does not distract.
- The hotspot is moved half its width to the top and left, to accurately display the position.

