### PR TITLE
Incorrect Import @ Usage Docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,12 +27,12 @@ yarn add sanity-plugin-hotspot-array
 Add it as a plugin in sanity.config.ts (or .js):
 
 ```js
-import { imageHotspotArray } from "sanity-plugin-hotspot-array";
+import { imageHotspotArrayPlugin } from "sanity-plugin-hotspot-array";
 
 export default defineConfig({
   // ...
   plugins: [
-    imageHotspotArray(),
+    imageHotspotArrayPlugin(),
   ] 
 })
 ```


### PR DESCRIPTION
Currently in the Usage docs, the _Add it as a plugin in sanity.config.ts_ step has the following snippet:

```js
import { imageHotspotArray } from "sanity-plugin-hotspot-array";

export default defineConfig({
  // ...
  plugins: [
    imageHotspotArray(),
  ] 
})
```

This is incorrect and throws an error. It should be:

```js
import { imageHotspotArrayPlugin } from "sanity-plugin-hotspot-array";

export default defineConfig({
  // ...
  plugins: [
    imageHotspotArrayPlugin(),
  ] 
})
```