### PR TITLE
fix: prevent tooltip from resetting tooltip position

### DIFF
--- a/src/Spot.tsx
+++ b/src/Spot.tsx
@@ -142,58 +142,60 @@ export default function Spot({
   }
 
   return (
-    <Tooltip
-      key={value._key}
-      disabled={isDragging}
-      portal
-      content={
-        tooltip && typeof tooltip === 'function' ? (
-          createElement(tooltip, {value, renderPreview, schemaType})
-        ) : (
-          <Box padding={2} style={{maxWidth: 200, pointerEvents: `none`}}>
-            <Text textOverflow="ellipsis">
-              {hotspotDescriptionPath
-                ? (get(value, hotspotDescriptionPath) as string)
-                : `${value.x}% x ${value.y}%`}
-            </Text>
-          </Box>
-        )
-      }
+    <motion.div
+      drag
+      dragConstraints={bounds}
+      dragElastic={0}
+      dragMomentum={false}
+      onDragEnd={handleDragEnd}
+      onDragStart={handleDragStart}
+      onHoverStart={handleHoverStart}
+      onHoverEnd={handleHoverEnd}
+      style={{
+        ...dragStyle,
+        x,
+        y,
+        ...(isDragging && {...dragStyleWhileDrag}),
+        ...(isHovering && {...dragStyleWhileHover}),
+      }}
     >
-      <motion.div
-        drag
-        dragConstraints={bounds}
-        dragElastic={0}
-        dragMomentum={false}
-        onDragEnd={handleDragEnd}
-        onDragStart={handleDragStart}
-        onHoverStart={handleHoverStart}
-        onHoverEnd={handleHoverEnd}
-        style={{
-          ...dragStyle,
-          x,
-          y,
-          ...(isDragging && {...dragStyleWhileDrag}),
-          ...(isHovering && {...dragStyleWhileHover}),
-        }}
+      <Tooltip
+        key={value._key}
+        disabled={isDragging}
+        portal
+        content={
+          tooltip && typeof tooltip === 'function' ? (
+            createElement(tooltip, {value, renderPreview, schemaType})
+          ) : (
+            <Box padding={2} style={{maxWidth: 200, pointerEvents: `none`}}>
+              <Text textOverflow="ellipsis">
+                {hotspotDescriptionPath
+                  ? (get(value, hotspotDescriptionPath) as string)
+                  : `${value.x}% x ${value.y}%`}
+              </Text>
+            </Box>
+          )
+        }
       >
-        {/* Dot */}
-        <Box
-          style={{
-            ...dotStyle,
-            ...((isDragging || isHovering) && {...dotStyleWhileActive}),
-          }}
-        />
-        {/* Label */}
-        <div
-          style={{
-            ...labelStyle,
-            ...((isDragging || isHovering) && {...labelStyleWhileActive}),
-          }}
-        >
-          {index + 1}
+        <div>
+          {/* Dot */}
+          <Box
+            style={{
+              ...dotStyle,
+              ...((isDragging || isHovering) && {...dotStyleWhileActive}),
+            }}
+          />
+          {/* Label */}
+          <div
+            style={{
+              ...labelStyle,
+              ...((isDragging || isHovering) && {...labelStyleWhileActive}),
+            }}
+          >
+            {index + 1}
+          </div>
         </div>
-      </motion.div>
-    </Tooltip>
+      </Tooltip>
+    </motion.div>
   )
 }


### PR DESCRIPTION
This PR resolves the issue where disabling the tooltip caused the draggable dot's position to reset. The fix involves moving the motion.div outside of the tooltip, ensuring that the tooltip no longer interferes with the drag functionality.

Fix for: https://github.com/sanity-io/sanity-plugin-hotspot-array/issues/24