### PR TITLE
fix: fallback to rootObject if imagePath is empty

### DIFF
--- a/src/ImageHotspotArray.tsx
+++ b/src/ImageHotspotArray.tsx
@@ -75,7 +75,7 @@ export function ImageHotspotArray(
    * check if there are any changes to the hotspotImage and update the reference
    */
   const hotspotImage = useMemo(() => {
-    return get(rootObject, imageHotspotOptions.imagePath) as ImageValue | undefined
+    return (!imageHotspotOptions.imagePath ? rootObject : get(rootObject, imageHotspotOptions.imagePath)) as ImageValue | undefined
   }, [rootObject, imageHotspotOptions.imagePath])
 
   const displayImage = useMemo(() => {


### PR DESCRIPTION
I've wanted to use `pathRoot: 'parent'` but that results in the rootObject being the field I want to use, passing this to lodash's get with an empty `imagePath` returns an undefined, so here's something that will allow for rootObject to be returned when `imagePath` is an empty string