### PR TITLE
fix(deps): allow studio v4 in peer dep ranges

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -106,12 +106,21 @@ jobs:
     runs-on: ubuntu-latest
     name: Semantic release
     steps:
-      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # tag=v3
+      - uses: actions/create-github-app-token@v2
+        id: app-token
+        with:
+          app-id: ${{ secrets.ECOSPARK_APP_ID }}
+          private-key: ${{ secrets.ECOSPARK_APP_PRIVATE_KEY }}
+      - uses: actions/checkout@v4
         with:
           # Need to fetch entire commit history to
           # analyze every commit since last release
           fetch-depth: 0
-      - uses: actions/setup-node@8c91899e586c5b171469028077307d293428b516 # tag=v3
+          # Uses generated token to allow pushing commits back
+          token: ${{ steps.app-token.outputs.token }}
+          # Make sure the value of GITHUB_TOKEN will not be persisted in repo's config
+          persist-credentials: false
+      - uses: actions/setup-node@v4 # tag=v3
         with:
           cache: npm
           node-version: lts/*
@@ -128,5 +137,5 @@ jobs:
       - run: npx semantic-release --dry-run --debug
         if: failure()
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           NPM_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -50,7 +50,7 @@
       "peerDependencies": {
         "@sanity/ui": "^2",
         "react": "^18.3 || ^19",
-        "sanity": "^3",
+        "sanity": "^3 || ^4.0.0-0",
         "styled-components": "^6.1"
       }
     },

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
   "peerDependencies": {
     "@sanity/ui": "^2",
     "react": "^18.3 || ^19",
-    "sanity": "^3",
+    "sanity": "^3 || ^4.0.0-0",
     "styled-components": "^6.1"
   },
   "engines": {


### PR DESCRIPTION
### Description

Prepping for July 15th: https://www.sanity.io/blog/a-major-version-bump-for-a-minor-reason#299526b398ec

Currently when using a package.json like: 
```
Progress: resolved 1030, reused 961, downloaded 19, added 980, done
 WARN  Issues with peer dependencies found
.
└─┬ sanity-plugin-hotspot-array 2.2.0
  └── ✕ unmet peer sanity@^3: found 4.0.0-0
```
This fixes it.

### Testing

Tested locally